### PR TITLE
Python 3.8 compatibility:

### DIFF
--- a/setup_totp.py
+++ b/setup_totp.py
@@ -4,11 +4,11 @@ from setuptools import find_packages, setup
 
 setup(
     name='totp-manager',
-    version='2.0',
+    version='2.0.1',
     description='A tool for generating time-based one-time passwords (TOTP) for services requiring multi-factor authentication (MFA), and for encrypting/managing the underlying MFA secret keys.',
     author='David M. Rosson',
     author_email='david.rosson@gmail.com',
     packages=find_packages(),
     scripts=['totp-encryptor', 'totp'],
-    install_requires=['pycrypto', 'pyotp', 'pyperclip']
+    install_requires=['pycryptodome', 'pyotp', 'pyperclip']
 )

--- a/totp
+++ b/totp
@@ -2,7 +2,7 @@
 
 """
 Install local Python 3.x dependencies:
-  - sudo pip install pycrypto
+  - sudo pip install pycryptodome
   - sudo pip install pyotp
   - sudo pip install pyperclip
 """
@@ -128,7 +128,7 @@ def decrypt(pin, enc):
 
 
 def keygen(key):
-    return md5(key.encode('utf8')).hexdigest()
+    return md5(key.encode('utf8')).hexdigest().encode('utf8')
 
 
 def backtrack(rows):

--- a/totp-encryptor
+++ b/totp-encryptor
@@ -2,7 +2,7 @@
 
 """
 Install local Python 3.x dependency:
-  - sudo pip install pycrypto
+  - sudo pip install pycryptodome
 """
 
 
@@ -483,7 +483,7 @@ def encrypt(pin, raw):
     raw = pad(raw)
     iv = Random.new().read(AES.block_size)
     cipher = AES.new(keygen(pin), AES.MODE_CBC, iv)
-    return b64encode(iv + cipher.encrypt(raw))
+    return b64encode(iv + cipher.encrypt(raw.encode('utf8'))).decode('utf8')
 
 
 def decrypt(pin, enc):
@@ -494,7 +494,7 @@ def decrypt(pin, enc):
 
 
 def keygen(key):
-    return md5(key.encode('utf8')).hexdigest()
+    return md5(key.encode('utf8')).hexdigest().encode('utf8')
 
 
 def process_file(data):


### PR DESCRIPTION
- Switch from 'pycrypto' to 'pycryptodome'.
- Use 'utf-8' encoding and decoding.